### PR TITLE
set readme heading to project name

### DIFF
--- a/__tests__/generators/app/index-spec.ts
+++ b/__tests__/generators/app/index-spec.ts
@@ -12,7 +12,17 @@ test('Should export default class', () => {
 });
 
 test('Should create static files', async () => {
-  const expected = ['.gitignore', '.gitattributes', 'Makefile', 'README.md'];
+  const expected = ['.gitignore', '.gitattributes', 'Makefile'];
+
+  await helpers
+    .run(path.join(__dirname, appModule))
+    .withPrompts({ provider: 'aws' });
+
+  assert.file(expected);
+});
+
+test('Should create readme', async () => {
+  const expected = ['README.md'];
 
   await helpers
     .run(path.join(__dirname, appModule))

--- a/src/generators/app/index.ts
+++ b/src/generators/app/index.ts
@@ -20,7 +20,6 @@ export default class extends Generator {
   private statciFiles = [
     ['dotgitignore', '.gitignore'],
     ['dotgitattributes', '.gitattributes'],
-    ['README.md', 'README.md'],
     ['Makefile', 'Makefile'],
   ];
 
@@ -43,6 +42,7 @@ export default class extends Generator {
     this.log('copying files');
 
     this._copyStaticFiles();
+    this._copyReadme();
     this._createEnvironments();
     this._createMain();
     this._createModule();
@@ -67,6 +67,16 @@ export default class extends Generator {
         this.destinationPath(fileCopyTuple[1])
       );
     });
+  }
+
+  private _copyReadme() {
+    const projectName = this.contextRoot.split('/').pop();
+
+    this.fs.copyTpl(
+      this.templatePath('README.md'),
+      this.destinationPath('README.md'),
+      { heading: projectName }
+    );
   }
 
   private _createEnvironments(): void {

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -1,1 +1,1 @@
-# Terraform Infrastucture Project
+# <%= heading %>


### PR DESCRIPTION
closes #1 

The heading of the generated README.md is set to the name of the current directory (the project name)